### PR TITLE
ENG-950 importing bom and bumped parent pom

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -9,3 +9,9 @@ pipelineConfig:
       value: "true"
     - name: UPDATE_OWASP_DB
       value: "false"
+  pipelines:
+      release:
+        promote:
+          steps:
+            - name: update bom
+              sh: update-bom

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-core-parent</artifactId>
-        <version>6.2.14</version>
+        <version>6.2.15</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-portal-ui</artifactId>
@@ -201,30 +201,36 @@
             </plugins>
         </pluginManagement>
     </build>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.entando</groupId>
+                <artifactId>entando-core-bom</artifactId>
+                <version>6.2.3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-engine</artifactId>
-            <version>${entando-engine.version}</version>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-engine</artifactId>
-            <version>${entando-engine.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
-            <version>${entando-admin-console.version}</version>
             <classifier>classes</classifier>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
-            <version>${entando-admin-console.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
The purpose of this Pr is to publish the portal-ui latest version to the shared entando-parent-bom/pom.xml file and trigger a rebuild of the project in question. This project now also uses the bom and uses the latest version of entando-core-parent.