### PR TITLE
ENG-2593 Removing unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-core-parent</artifactId>
-        <version>6.4.24</version>
+        <version>6.4.25</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-portal-ui</artifactId>
@@ -204,7 +204,7 @@
             <dependency>
                 <groupId>org.entando</groupId>
                 <artifactId>entando-core-bom</artifactId>
-                <version>6.4.77</version>
+                <version>6.4.88</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-core-parent</artifactId>
-        <version>6.4.23</version>
+        <version>6.4.24</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-portal-ui</artifactId>
@@ -222,13 +222,8 @@
             <groupId>org.owasp.esapi</groupId>
             <artifactId>esapi</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-        </dependency>
         <!-- esapi - end of section -->
-
+		
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
@@ -238,6 +233,38 @@
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>
@@ -264,14 +291,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyclient</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
Before:

[WARNING] Used undeclared dependencies found:
[WARNING]    org.entando.entando:entando-engine:jar:6.4.20:compile
[WARNING]    commons-beanutils:commons-beanutils:jar:1.9.4:compile
[WARNING]    org.springframework:spring-context:jar:5.3.9:compile
[WARNING]    commons-lang:commons-lang:jar:2.6:compile
[WARNING]    org.freemarker:freemarker:jar:2.3.31:compile
[WARNING]    org.apache.commons:commons-lang3:jar:3.12.0:compile
[WARNING]    org.springframework:spring-beans:jar:5.3.9:compile
[WARNING]    org.springframework:spring-web:jar:5.3.9:compile
[WARNING]    org.slf4j:slf4j-api:jar:1.7.31:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.entando.entando:entando-admin-console:jar:classes:6.4.11:compile
[WARNING]    xom:xom:jar:1.3.7:compile
[WARNING]    javax.servlet.jsp:jsp-api:jar:2.2:provided
[WARNING]    org.entando.entando:entando-admin-console:test-jar:tests:6.4.11:test
[WARNING]    org.junit.jupiter:junit-jupiter:jar:5.7.2:test
[WARNING]    org.mockito:mockito-junit-jupiter:jar:3.11.2:test
[WARNING]    org.apache.derby:derbyclient:jar:10.9.1.0:test
[WARNING]    org.apache.derby:derby:jar:10.9.1.0:test

After:

[WARNING] Used undeclared dependencies found:
[WARNING]    org.entando.entando:entando-engine:jar:6.4.20:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.entando.entando:entando-admin-console:jar:classes:6.4.11:compile
[WARNING]    javax.servlet.jsp:jsp-api:jar:2.2:provided
[WARNING]    org.entando.entando:entando-admin-console:test-jar:tests:6.4.11:test
[WARNING]    org.junit.jupiter:junit-jupiter:jar:5.7.2:test
[WARNING]    org.apache.derby:derby:jar:10.9.1.0:test